### PR TITLE
Change mathjax link to load from https or http

### DIFF
--- a/_includes/mathjs
+++ b/_includes/mathjs
@@ -1,1 +1,1 @@
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
`//` tells the browser to pick the one that it wants. Currently, in my browser (Chromium 57.0.2987.98), the https version of the blog doesn't load the mathjax script, making the equations invisible. This fixes that issue.

This should fix the equations on https.